### PR TITLE
fix(metadata): update URLs and improve description consistency

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next"
 import { notFound } from "next/navigation"
 import defaultMdxComponents from "fumadocs-ui/mdx"
 import {
@@ -43,14 +44,19 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata(props: {
-  params: Promise<{ slug?: string[] }>
-}) {
+  params: Promise<{ slug: string[] }>
+}): Promise<Metadata> {
   const params = await props.params
   const page = source.getPage(params.slug)
+
   if (!page) notFound()
+
+  const description =
+    page.data.description ??
+    "AnnUI is a collection of reusable components that you can copy and paste into your web apps."
 
   return {
     title: page.data.title,
-    description: page.data.description,
+    description,
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,20 +39,20 @@ export const metadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://annui.org",
+    url: "https://www.annui.org",
     title: "AnnUI - Modern React Component Library",
     description:
-      "AnnUI is a collection of re-usable components that you can copy and paste into your web apps.",
+      "AnnUI is a collection of reusable components that you can copy and paste into your web apps.",
     siteName: "AnnUI",
   },
   twitter: {
     card: "summary_large_image",
     title: "AnnUI - Modern React Component Library",
     description:
-      "AnnUI is a collection of re-usable components that you can copy and paste into your web apps.",
+      "AnnUI is a collection of reusable components that you can copy and paste into your web apps.",
     creator: "@liorael",
   },
-  metadataBase: new URL("https://annui.org"),
+  metadataBase: new URL("https://www.annui.org"),
 }
 
 export default function Layout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
- Changed the base URL and Open Graph URL from "https://annui.org" to "https://www.annui.org" for better accessibility.
- Corrected the spelling of "re-usable" to "reusable" in the metadata descriptions for consistency.
- Enhanced the metadata generation in the documentation page to provide a default description if none is available.