### PR TITLE
fix: downgrade framer-motion and motion dependencies for compatibility

### DIFF
--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -39,8 +39,8 @@ const components = {
       {children}
     </Tabs>
   ),
-  Tab: (props: React.ComponentProps<typeof FumadocsTab>) => (
-    <TabsContent {...props} />
+  Tab: ({ value, ...props }: React.ComponentProps<typeof FumadocsTab>) => (
+    <TabsContent value={value!} {...props} />
   ),
   Steps,
   Step,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "geist": "^1.3.1",
     "lodash.template": "^4.5.0",
     "lucide-react": "^0.458.0",
-    "motion": "12.0.0-alpha.2",
+    "motion": "11.15.0",
     "next": "15.1.1",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^0.458.0
         version: 0.458.0(react@19.0.0)
       motion:
-        specifier: 12.0.0-alpha.2
-        version: 12.0.0-alpha.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 11.15.0
+        version: 11.15.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next:
         specifier: 15.1.1
         version: 15.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2002,12 +2002,12 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
-  framer-motion@12.0.0-alpha.2:
-    resolution: {integrity: sha512-s603YLhCoX3GKaPDZnywwoFdd1T6gDFCfevVRek+TCpbvazUkITh+YZ3a6kqTvn4Aj7qQWT3vAmzWIjl/LsCFA==}
+  framer-motion@11.15.0:
+    resolution: {integrity: sha512-MLk8IvZntxOMg7lDBLw2qgTHHv664bYoYmnFTmE0Gm/FW67aOJk0WM3ctMcG+Xhcv+vh5uyyXwxvxhSeJzSe+w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^19.0.0-rc.1
-      react-dom: ^19.0.0-rc.1
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -2676,12 +2676,18 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  motion@12.0.0-alpha.2:
-    resolution: {integrity: sha512-pslRUURjyS1Xb6lSdyc4LzOKhaCRj0PIqstb5dDIB/RxNO3MqSMU43o1rGtZs5h8DgRzRSPHE+E7yhh2NpwI8A==}
+  motion-dom@11.14.3:
+    resolution: {integrity: sha512-lW+D2wBy5vxLJi6aCP0xyxTxlTfiu+b+zcpVbGVFUxotwThqhdpPRSmX8xztAgtZMPMeU0WGVn/k1w4I+TbPqA==}
+
+  motion-utils@11.14.3:
+    resolution: {integrity: sha512-Xg+8xnqIJTpr0L/cidfTTBFkvRw26ZtGGuIhA94J9PQ2p4mEa06Xx7QVYZH0BP+EpMSaDlu+q0I0mmvwADPsaQ==}
+
+  motion@11.15.0:
+    resolution: {integrity: sha512-iZ7dwADQJWGsqsSkBhNHdI2LyYWU+hA1Nhy357wCLZq1yHxGImgt3l7Yv0HT/WOskcYDq9nxdedyl4zUv7UFFw==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^19.0.0-rc.1
-      react-dom: ^19.0.0-rc.1
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -5447,8 +5453,10 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@12.0.0-alpha.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  framer-motion@11.15.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
+      motion-dom: 11.14.3
+      motion-utils: 11.14.3
       tslib: 2.8.1
     optionalDependencies:
       react: 19.0.0
@@ -6444,9 +6452,13 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  motion@12.0.0-alpha.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  motion-dom@11.14.3: {}
+
+  motion-utils@11.14.3: {}
+
+  motion@11.15.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      framer-motion: 12.0.0-alpha.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      framer-motion: 11.15.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tslib: 2.8.1
     optionalDependencies:
       react: 19.0.0

--- a/registry/default/annui/image-carousel.tsx
+++ b/registry/default/annui/image-carousel.tsx
@@ -41,6 +41,7 @@ const ImageCarouselItem = React.forwardRef<
   HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof motion.div> & {
     value: string
+    children: React.ReactNode
   }
 >(({ children, value, className, ...props }, ref) => {
   const { activeValue, setActiveValue, collapsible } = useImageCarouselContext()
@@ -149,7 +150,7 @@ ImageCarouselItemTitle.displayName = "ImageCarouselItemTitle"
 
 const ImageCarouselItemDescription = React.forwardRef<
   HTMLDivElement,
-  React.ComponentPropsWithoutRef<"div">
+  React.ComponentPropsWithoutRef<typeof motion.div>
 >(({ className, ...props }, ref) => {
   const { isActive } = useImageCarouselItemContext()
 


### PR DESCRIPTION
- Downgraded `framer-motion` from `12.0.0-alpha.2` to `11.15.0` in `package.json` and updated corresponding entries in `pnpm-lock.yaml`.
- Adjusted peer dependencies for `motion` to support React versions `^18.0.0 || ^19.0.0`.
- Updated `Tab` component in `mdx-components.tsx` to ensure proper value handling.
- Added `children` prop to `ImageCarouselItem` for better flexibility in `image-carousel.tsx`.